### PR TITLE
Migrate Devise::DeviseAuthyController#POST-disable_authy

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -88,9 +88,12 @@ class Devise::DeviseAuthyController < DeviseController
 
     begin
       delete_entity(mfa_config.verify_identity)
-      mfa_config.delete
-      resource.assign_attributes(authy_enabled: false, authy_id: nil)
-      resource.save(validate: false)
+
+      MfaConfig.transaction do 
+        mfa_config.delete
+        resource.assign_attributes(authy_enabled: false, authy_id: nil)
+        resource.save(validate: false)
+      end
 
       forget_device
       set_flash_message(:notice, :disabled)

--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -173,6 +173,14 @@ class Devise::DeviseAuthyController < DeviseController
 
   private
 
+  def delete_entity(identity)
+    @verify_client.delete_entity(identity) unless identity.blank?
+  rescue StandardError => e
+    # 20404 means the resource does not exist. This can happen if an old unverified factor has
+    # already been cleaned up (i.e. deleted) by Verify.
+    raise e unless e.message.include?('20404')
+  end
+
   def authenticate_scope!
     send(:"authenticate_#{resource_name}!", :force => true)
     self.resource = send("current_#{resource_name}")
@@ -206,14 +214,6 @@ class Devise::DeviseAuthyController < DeviseController
   end
 
   protected
-
-  def delete_entity(identity)
-    @verify_client.delete_entity(identity) unless identity.blank?
-  rescue StandardError => e
-    # 20404 means the resource does not exist. This can happen if an old unverified factor has
-    # already been cleaned up (i.e. deleted) by Verify.
-    raise e unless e.message.include?('20404')
-  end
 
   def after_authy_enabled_path_for(resource)
     root_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,10 +19,10 @@ en:
 
     devise_authy:
       user:
-        enabled: 'Two factor authentication was enabled'
-        not_enabled: 'Something went wrong while enabling two factor authentication'
-        disabled: 'Two factor authentication was disabled'
-        not_disabled: 'Something went wrong while disabling two factor authentication'
-        signed_in: 'Signed in with Authy successfully.'
-        already_enabled: 'Two factor authentication is already enabled.'
+        enabled: 'Multi-factor authentication was enabled'
+        not_enabled: 'Something went wrong while enabling multi-factor authentication'
+        disabled: 'Multi-factor authentication was disabled'
+        not_disabled: 'Something went wrong while disabling Multi-factor authentication'
+        signed_in: ''
+        already_enabled: 'Multi-factor authentication is already enabled.'
         invalid_token: 'The entered token is invalid'

--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
           it "should redirect to the root_path and set a flash notice" do
             expect(response).to redirect_to(root_path)
-            expect(flash[:notice]).not_to be_nil
+            expect(flash[:notice]).to be_nil # we don't have a default signin message
             expect(flash[:error]).to be nil
           end
 

--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -493,7 +493,7 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
           end
 
           it "shows an error flash" do
-            expect(flash[:error]).to eq("Something went wrong while enabling two factor authentication")
+            expect(flash[:error]).to eq("Something went wrong while enabling multi-factor authentication")
           end
 
           it "renders enable_authy page again" do
@@ -592,7 +592,7 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
             it "should set a flash notice and redirect" do
               expect(response).to redirect_to(root_path)
-              expect(flash[:notice]).to eq('Two factor authentication was enabled')
+              expect(flash[:notice]).to eq('Multi-factor authentication was enabled')
             end
 
             it "should not set a remember_device cookie" do
@@ -619,7 +619,7 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
             end
             it "should set a flash notice and redirect" do
               expect(response).to redirect_to(root_path)
-              expect(flash[:notice]).to eq('Two factor authentication was enabled')
+              expect(flash[:notice]).to eq('Multi-factor authentication was enabled')
             end
 
             it "should set a signed remember_device cookie" do
@@ -648,7 +648,7 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
             it "should set an error flash and render verify_authy_installation" do
               expect(response).to render_template('verify_authy_installation')
-              expect(flash[:error]).to eq('Something went wrong while enabling two factor authentication')
+              expect(flash[:error]).to eq('Something went wrong while enabling multi-factor authentication')
             end
           end
 
@@ -680,93 +680,62 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
       end
 
       describe "POST disable_authy" do
-        describe "successfully" do
+        describe 'successfully' do
           before(:each) do
             cookies.signed[:remember_device] = {
-              :value => {expires: Time.now.to_i, id: user.id}.to_json,
-              :secure => false,
-              :expires => User.authy_remember_device.from_now
+              value: { expires: Time.now.to_i, id: user.id }.to_json,
+              secure: false,
+              expires: User.authy_remember_device.from_now
             }
-            expect(Authy::API).to receive(:delete_user)
-              .with(:id => user.authy_id)
-              .and_return(double("Authy::Response", :ok? => true))
+            expect_any_instance_of(TwilioVerifyClient).to receive(:delete_entity)
+              .with(user.mfa_config.verify_identity)
+              .and_return(true)
 
             post :POST_disable_authy
           end
 
-          it "should disable 2FA" do
+          it 'should disable 2FA' do
             user.reload
             expect(user.authy_id).to be nil
             expect(user.authy_enabled).to be false
           end
 
-          it "should forget the device cookie" do
+          it 'should forget the device cookie' do
             expect(response.cookies[:remember_device]).to be nil
           end
 
-          it "should set a flash notice and redirect" do
-            expect(flash.now[:notice]).to eq("Two factor authentication was disabled")
+          it 'should set a flash notice and redirect' do
+            expect(flash.now[:notice]).to eq('Multi-factor authentication was disabled')
             expect(response).to redirect_to(root_path)
           end
         end
 
-        describe "with more than one user using the same authy_id" do
-          # It is valid for more than one user to share an authy_id
-          # https://github.com/twilio/authy-devise/issues/143
+        describe 'unsuccessfully' do
           before(:each) do
-            @other_user = create(:authy_user, :authy_id => user.authy_id)
             cookies.signed[:remember_device] = {
-              :value => {expires: Time.now.to_i, id: user.id}.to_json,
-              :secure => false,
-              :expires => User.authy_remember_device.from_now
+              value: { expires: Time.now.to_i, id: user.id }.to_json,
+              secure: false,
+              expires: User.authy_remember_device.from_now
             }
-            expect(Authy::API).not_to receive(:delete_user)
+            expect_any_instance_of(TwilioVerifyClient).to receive(:delete_entity)
+              .with(user.mfa_config.verify_identity)
+              .and_raise(StandardError)
 
             post :POST_disable_authy
           end
 
-          it "should disable 2FA" do
-            user.reload
-            expect(user.authy_id).to be nil
-            expect(user.authy_enabled).to be false
-          end
-
-          it "should forget the device cookie" do
-            expect(response.cookies[:remember_device]).to be nil
-          end
-
-          it "should set a flash notice and redirect" do
-            expect(flash.now[:notice]).to eq("Two factor authentication was disabled")
-            expect(response).to redirect_to(root_path)
-          end
-        end
-
-        describe "unsuccessfully" do
-          before(:each) do
-            cookies.signed[:remember_device] = {
-              :value => {expires: Time.now.to_i, id: user.id}.to_json,
-              :secure => false,
-              :expires => User.authy_remember_device.from_now
-            }
-            expect(Authy::API).to receive(:delete_user)
-              .with(:id => user.authy_id)
-              .and_return(double("Authy::Response", :ok? => false))
-
-            post :POST_disable_authy
-          end
-
-          it "should not disable 2FA" do
+          it 'should not disable 2FA' do
             user.reload
             expect(user.authy_id).not_to be nil
             expect(user.authy_enabled).to be true
           end
 
-          it "should not forget the device cookie" do
+          it 'should not forget the device cookie' do
             expect(cookies[:remember_device]).not_to be_nil
           end
 
-          it "should set a flash error and redirect" do
-            expect(flash[:error]).to eq("Something went wrong while disabling two factor authentication")
+          it 'should set a flash error and redirect' do
+            expect(flash[:error]).to eq('Something went wrong while disabling Multi-factor authentication')
             expect(response).to redirect_to(root_path)
           end
         end

--- a/spec/generators/devise_authy/install_generator_spec.rb
+++ b/spec/generators/devise_authy/install_generator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe DeviseAuthy::Generators::InstallGenerator, type: :generator do
         directory "config" do
           directory "locales" do
             file "devise.authy.en.yml" do
-              contains "Two factor authentication was enabled"
+              contains "Multi-factor authentication was enabled"
             end
           end
         end


### PR DESCRIPTION
Disables MFA and deletes all MFA config for the resource across all factors.