### PR TITLE
Migrate DeviseAuthyController#GET_verify_authy_installation

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -112,11 +112,9 @@ class Devise::DeviseAuthyController < DeviseController
     redirect_to after_authy_disabled_path_for(resource)
   end
 
+  # The verify_authy_installation endpoints are for verification on registration. Verification
+  # on login is handled by the verify_authy methods (the ones without 'installation' in the name).
   def GET_verify_authy_installation
-    if resource_class.authy_enable_qr_code
-      response = Authy::API.request_qr_code(id: resource.authy_id)
-      @authy_qr_code = response.qr_code
-    end
     render :verify_authy_installation
   end
 

--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -110,9 +110,11 @@ class Devise::DeviseAuthyController < DeviseController
     redirect_to after_authy_disabled_path_for(resource)
   end
 
-  # The verify_authy_installation endpoints are for verification on registration. Verification
-  # on login is handled by the verify_authy methods (the ones without 'installation' in the name).
   def GET_verify_authy_installation
+    if resource_class.authy_enable_qr_code
+      response = Authy::API.request_qr_code(id: resource.authy_id)
+      @authy_qr_code = response.qr_code
+    end
     render :verify_authy_installation
   end
 

--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -111,9 +111,10 @@ class Devise::DeviseAuthyController < DeviseController
   end
 
   def GET_verify_authy_installation
-    if resource_class.authy_enable_qr_code
-      response = Authy::API.request_qr_code(id: resource.authy_id)
-      @authy_qr_code = response.qr_code
+    if resource.mfa_config.qr_code_uri
+      uri = resource.mfa_config.qr_code_uri
+      # from https://gist.github.com/bf4/5188994
+      @verify_qr_code = RQRCode::QRCode.new(uri).as_png(size: 200).to_data_url
     end
     render :verify_authy_installation
   end

--- a/app/views/devise/verify_authy_installation.html.erb
+++ b/app/views/devise/verify_authy_installation.html.erb
@@ -1,7 +1,7 @@
 <h2><%= I18n.t('authy_verify_installation_title', scope: 'devise') %></h2>
 
-<% if @authy_qr_code %>
-  <%= image_tag @authy_qr_code, :size => '256x256', :alt => I18n.t('authy_qr_code_alt', scope: 'devise') %>
+<% if @verify_qr_code %>
+  <%= image_tag @verify_qr_code, :size => '200x200', :alt => I18n.t('authy_qr_code_alt', scope: 'devise') %>
   <p><%= I18n.t('authy_qr_code_instructions', scope: 'devise') %></p>
 <% end %>
 

--- a/app/views/devise/verify_authy_installation.html.haml
+++ b/app/views/devise/verify_authy_installation.html.haml
@@ -1,7 +1,7 @@
 %h2= I18n.t('authy_verify_installation_title', scope: 'devise')
 
-- if @authy_qr_code
-  = image_tag @authy_qr_code, :size => '256x256', :alt => I18n.t('authy_qr_code_alt', scope: 'devise')
+- if @verify_qr_code
+  = image_tag @verify_qr_code, :size => '256x256', :alt => I18n.t('authy_qr_code_alt', scope: 'devise')
   %p= I18n.t('authy_qr_code_instructions', scope: 'devise')
 
 = verify_authy_installation_form do

--- a/devise-authy.gemspec
+++ b/devise-authy.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "devise", ">= 4.0.0"
   spec.add_dependency "authy", "~> 3.0"
   spec.add_dependency "twilio-ruby", "~> 6.9"
+  spec.add_dependency "rqrcode", "~> 2.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2"
   spec.add_development_dependency "bundler", ">= 1.16"

--- a/lib/devise-authy.rb
+++ b/lib/devise-authy.rb
@@ -3,6 +3,7 @@ require 'active_support/concern'
 require 'active_support/core_ext/integer/time'
 require 'devise'
 require 'authy'
+require 'rqrcode'
 require_relative './twilio-verify-client'
 
 module Devise

--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -504,14 +504,13 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
               Devise.authy_enable_qr_code = false
             end
 
-            it "should hit API for a QR code" do
-              expect(Authy::API).to receive(:request_qr_code).with(
-                :id => user.authy_id
-              ).and_return(double("Authy::Request", :qr_code => 'https://example.com/qr.png'))
+            it "should generate a QR code" do
+
+              user.mfa_config.update(qr_code_uri: 'https://example.com/qr.png')
 
               get :GET_verify_authy_installation
               expect(response).to render_template('verify_authy_installation')
-              expect(assigns[:authy_qr_code]).to eq('https://example.com/qr.png')
+              expect(assigns[:authy_qr_code]).to_not be_nil;
             end
           end
         end

--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -510,7 +510,7 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
               get :GET_verify_authy_installation
               expect(response).to render_template('verify_authy_installation')
-              expect(assigns[:authy_qr_code]).to_not be_nil;
+              expect(assigns[:verify_qr_code]).to_not be_nil;
             end
           end
         end

--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -494,6 +494,26 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
             get :GET_verify_authy_installation
             expect(response).to render_template('verify_authy_installation')
           end
+
+          describe "with qr codes turned on" do
+            before(:each) do
+              Devise.authy_enable_qr_code = true
+            end
+
+            after(:each) do
+              Devise.authy_enable_qr_code = false
+            end
+
+            it "should hit API for a QR code" do
+              expect(Authy::API).to receive(:request_qr_code).with(
+                :id => user.authy_id
+              ).and_return(double("Authy::Request", :qr_code => 'https://example.com/qr.png'))
+
+              get :GET_verify_authy_installation
+              expect(response).to render_template('verify_authy_installation')
+              expect(assigns[:authy_qr_code]).to eq('https://example.com/qr.png')
+            end
+          end
         end
       end
 

--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -527,26 +527,6 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
             get :GET_verify_authy_installation
             expect(response).to render_template('verify_authy_installation')
           end
-
-          describe "with qr codes turned on" do
-            before(:each) do
-              Devise.authy_enable_qr_code = true
-            end
-
-            after(:each) do
-              Devise.authy_enable_qr_code = false
-            end
-
-            it "should hit API for a QR code" do
-              expect(Authy::API).to receive(:request_qr_code).with(
-                :id => user.authy_id
-              ).and_return(double("Authy::Request", :qr_code => 'https://example.com/qr.png'))
-
-              get :GET_verify_authy_installation
-              expect(response).to render_template('verify_authy_installation')
-              expect(assigns[:authy_qr_code]).to eq('https://example.com/qr.png')
-            end
-          end
         end
       end
 

--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -511,7 +511,7 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
               get :GET_verify_authy_installation
               expect(response).to render_template('verify_authy_installation')
-              expect(assigns[:verify_qr_code]).to_not be_nil;
+              expect(assigns[:verify_qr_code]).to_not be_nil
             end
           end
         end


### PR DESCRIPTION
Adds support for verifying whether a Twilio verify installation is setup instead of Authy.