### PR TITLE
Gitignore sqlite related files in the db folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ gemfiles/*.lock
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 
-**/*.sqlite
+**/*.sqlite*
 **/*.log
 
 initializers/authy.rb


### PR DESCRIPTION
Occasionally, when a spec run is terminated in the middle, there's a `spec/internal/db/devise-authy.sqlite-shm` file. I've also seen one with another file extension starting with `sqlite-` (I don't remember the specific one). These are really just internal to how SQLite handles journaling and error handling. Since those SQLite dbs are only used as part of the spec run, we don't want people committing these files either.