### PR TITLE
Gitignore the .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ initializers/authy.rb
 .byebug_history
 
 .rspec_status
+
+/.vscode


### PR DESCRIPTION
.vscode directories for VSCode users are generally only useful to an individual. Let's ignore it so we don't have to worry about folks committing it.