### PR TITLE
Add build for Ruby 3.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", 3.1, 3.2]
+        ruby: ["3.0", 3.1, 3.2, 3.3]
         gemfile: [rails_6, rails_6_1, rails_7, rails_7_1]
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile


### PR DESCRIPTION
Ruby 3.3 has been out since December so it's wise to test on that.