### PR TITLE
Rename test sqlite db

### DIFF
--- a/spec/internal/config/database.yml
+++ b/spec/internal/config/database.yml
@@ -1,3 +1,3 @@
 test:
   adapter: sqlite3
-  database: db/devise-authy.sqlite
+  database: db/devise-twilio-verify.sqlite


### PR DESCRIPTION
There's a SQLite db used for automated tests. It previously used authy its name so this changes that.