### PR TITLE
Remove reference to Authy::API#request_sms

### DIFF
--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -738,7 +738,6 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
   describe "requesting authentication tokens" do
     describe "without a user" do
       it "Should not request sms if user couldn't be found" do
-        expect(Authy::API).not_to receive(:request_sms)
         expect_any_instance_of(TwilioVerifyClient).not_to receive(:send_sms_verification_code)
 
         post :request_sms


### PR DESCRIPTION
We're not using Authy::API anymore so we shouldn't be verifying whether request_sms was called on it.