### PR TITLE
Remove broken rcov rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,11 +18,6 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
 
-RSpec::Core::RakeTask.new(:rcov) do |spec|
-  spec.pattern = 'spec/**/*_spec.rb'
-  spec.rcov = true
-end
-
 task :default => :spec
 
 require 'yard'


### PR DESCRIPTION
[rcov](https://github.com/relevance/rcov) is an abandoned code coverage tool for Ruby. It was apparently included in the authy-devise gem for testing originally but appears to have been abandoned at some point. The task doesn't work as rcov wasn't included anymore in the Gems. This removes the task as simplecov appears to be included already which is actually a supported code coverage tool.