### PR TITLE
Update copyright notices

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,7 @@
 Copyright (c) 2012-2021 Authy Inc
+Copyright (c) Midwest Access Coalition
+Copyright 2021 Jay Wolff
+Copyright (c) Contributors to https://github.com/MidwestAccessCoalition/twilio-verify-devise and associated repositories and projects
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 Copyright (c) 2012-2021 Authy Inc
-Copyright (c) Midwest Access Coalition
 Copyright 2021 Jay Wolff
-Copyright (c) Contributors to https://github.com/MidwestAccessCoalition/twilio-verify-devise and associated repositories and projects
+Copyright (c) Midwest Access Coalition
+Copyright (c) Contributors to https://github.com/MidwestAccessCoalition/twilio-verify-devise
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -263,4 +263,4 @@ For more information please read this article on [how we are discontinuing the T
 
 ## Copyright
 
-Copyright (c) 2012-2021 Authy Inc. See LICENSE.txt for further details.
+See LICENSE.txt for further details.


### PR DESCRIPTION
I realized that we didn't update the copyright notices in LICENSE.txt. As the MIT license requires us to keep previous copyright notices, I've kept Authy's and I've made the following additions:

* Midwest Access Coalition since the copyright of @camckin10 and I are assigned under contract to them. (And likely @BintLopez's is too)
* jayywolff since we often use his [repo](https://github.com/jayywolff/twilio-verify-devise) as reference
* A general line to cover the copyright of other contributors to the project.

I also removed the specific copyright line from the README since it just references the LICENSE.txt and it seems redundant.

NOTE: I purposely don't add a copyright year to the lines we can control. I've always been advised that the year is unnecessary. Someone has to keep it up to date and it doesn't add anything, the key is knowing who is licensing the work.
