### PR TITLE
Verify that LockableUser and User have a has_one to an mfa_config

### DIFF
--- a/spec/models/lockable_user_spec.rb
+++ b/spec/models/lockable_user_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe LockableUser, type: :model do
+  it {is_expected.to have_one(:mfa_config)}
+
   describe "with a user with an authy id" do
     let(:user) { create(:lockable_authy_user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe User, type: :model do
+  it {is_expected.to have_one(:mfa_config)}
+
   describe "with a user with an authy id" do
     let!(:user) { create(:authy_user) }
 


### PR DESCRIPTION
This helps verify that adding `devise :authy_authenticable` to a model, like User or LockableUser, actually adds the proper associations. In particular, a has_one to mfa_config.