### PR TITLE
Move setting the Twilio authenticators into an initializer

### DIFF
--- a/lib/devise-authy.rb
+++ b/lib/devise-authy.rb
@@ -7,7 +7,7 @@ require 'devise-authy/twilio-verify-client'
 require 'devise-authy/twilio-interactor'
 
 module Devise
-  mattr_accessor :authy_remember_device, :authy_enable_qr_code
+  mattr_accessor :authy_remember_device, :authy_enable_qr_code, :twilio_account_sid, :twilio_auth_token, :twilio_service_sid
   @@authy_remember_device = 1.month
   @@authy_enable_qr_code = false
 end

--- a/lib/devise-authy/rails.rb
+++ b/lib/devise-authy/rails.rb
@@ -10,6 +10,12 @@ module DeviseAuthy
     # extend mapping with after_initialize because it's not reloaded
     config.after_initialize do
       Devise::Mapping.send :prepend, DeviseAuthy::Mapping
+
+      # prefill the :twilio_account_sid, :twilio_auth_token, :twilio_service_sid
+      
+      Devise.twilio_account_sid = ENV['TWILIO_ACCOUNT_SID'] if Devise.twilio_account_sid.nil?
+      Devise.twilio_auth_token = ENV['TWILIO_AUTH_TOKEN'] if Devise.twilio_auth_token.nil?
+      Devise.twilio_service_sid = ENV['TWILIO_SERVICE_SID'] if Devise.twilio_service_sid.nil?
     end
   end
 end

--- a/lib/devise-authy/twilio-verify-client.rb
+++ b/lib/devise-authy/twilio-verify-client.rb
@@ -6,12 +6,9 @@ require 'twilio-ruby'
 module DeviseAuthy
   class TwilioVerifyClient
     # For development these values can be found in the Twilio Console at https://console.twilio.com.
-    TWILIO_ACCOUNT_SID = ENV['TWILIO_ACCOUNT_SID']
-    TWILIO_AUTH_TOKEN = ENV['TWILIO_AUTH_TOKEN']
-    TWILIO_SERVICE_SID = ENV['TWILIO_VERIFY_SERVICE_SID']
 
     def initialize
-      @client = Twilio::REST::Client.new(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)
+      @client = Twilio::REST::Client.new(Devise.twilio_account_sid, Devise.twilio_auth_token)
     end
 
     #################################
@@ -19,7 +16,7 @@ module DeviseAuthy
     #################################
     def register_totp_factor(identity, friendly_name)
       @client.verify.v2
-             .services(TWILIO_SERVICE_SID)
+             .services(Devise.twilio_service_sid)
              .entities(identity)
              .new_factors
              .create(
@@ -30,7 +27,7 @@ module DeviseAuthy
 
     def validate_totp_registration(identity, factor_id, code)
       response = @client.verify.v2
-                        .services(TWILIO_SERVICE_SID)
+                        .services(Devise.twilio_service_sid)
                         .entities(identity)
                         .factors(factor_id)
                         .update(auth_payload: code)
@@ -39,7 +36,7 @@ module DeviseAuthy
 
     def validate_totp_token(identity, factor_id, code)
       response = @client.verify.v2
-                        .services(TWILIO_SERVICE_SID)
+                        .services(Devise.twilio_service_sid)
                         .entities(identity)
                         .challenges
                         .create(
@@ -52,7 +49,7 @@ module DeviseAuthy
     # Returns true if successful.
     def delete_totp_factor(identity, factor_id)
       @client.verify.v2
-             .services(TWILIO_SERVICE_SID)
+             .services(Devise.twilio_service_sid)
              .entities(identity)
              .factors(factor_id)
              .delete
@@ -61,7 +58,7 @@ module DeviseAuthy
     # Returns true if successful.
     def delete_entity(identity)
       @client.verify.v2
-             .services(TWILIO_SERVICE_SID)
+             .services(Devise.twilio_service_sid)
              .entities(identity)
              .delete
     end
@@ -71,7 +68,7 @@ module DeviseAuthy
     #################################
     def send_sms_verification_code(country_code, phone_number)
       response = @client.verify.v2
-                        .services(TWILIO_SERVICE_SID)
+                        .services(Devise.twilio_service_sid)
                         .verifications
                         .create(to: "+#{country_code}#{phone_number}", channel: 'sms')
       response.status
@@ -79,7 +76,7 @@ module DeviseAuthy
 
     def check_sms_verification_code(country_code, phone_number, code)
       response = @client.verify.v2
-                        .services(TWILIO_SERVICE_SID)
+                        .services(Devise.twilio_service_sid)
                         .verification_checks
                         .create(to: "+#{country_code}#{phone_number}", code: code, channel: 'sms')
       response.status
@@ -91,7 +88,7 @@ module DeviseAuthy
 
     def send_call_verification_code(country_code, phone_number)
       response = @client.verify.v2
-                        .services(TWILIO_SERVICE_SID)
+                        .services(Devise.twilio_service_sid)
                         .verifications
                         .create(to: "+#{country_code}#{phone_number}", channel: 'call')
       response.status


### PR DESCRIPTION
So this was a weird one:

Previously, we were setting the Twilio auth information as a const based upon the ENV variables. That works fine if the env variables are set when the process starts. Unfortunately, it doesn't work if you are getting them from a .env file. Why? Because you can't reliably expect the .env to be loaded prior to this Gem.

To work around this, I added these as Devise module accessors and I'm setting them in the after_initialize callback for the Railtie. I believe this also allows us to override these values in a Devise initializer but I could be wrong.