### PR TITLE
Remove bad channel argument from check_sms_verification_code

### DIFF
--- a/lib/devise-authy/twilio-verify-client.rb
+++ b/lib/devise-authy/twilio-verify-client.rb
@@ -81,7 +81,7 @@ module DeviseAuthy
       response = @client.verify.v2
                         .services(TWILIO_SERVICE_SID)
                         .verification_checks
-                        .create(to: "+#{country_code}#{phone_number}", code: code, channel: 'sms')
+                        .create(to: "+#{country_code}#{phone_number}", code: code)
       response.status
     end
 


### PR DESCRIPTION
The channel keyword argument causes an ArgumentError to be thrown since it's not appropriate. This removes it.