### PR TITLE
Allow workflow_dispatch on build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
workflow_dispatch allows us to manually run a workflow from the the action tab. That would be helpful as we debug this what's wrong with the CI.