### PR TITLE
Add the concurrent-ruby lock fix and corrects installing Gems on Ruby 3.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,5 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: bundle exec rspec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - name: Install dependencies
         run: bundle install
       - name: Run tests

--- a/Appraisals
+++ b/Appraisals
@@ -3,6 +3,7 @@ appraise "rails-6--twilio-6" do
   gem "sqlite3", "~> 1.4"
   gem "twilio-ruby", "~> 6.9"
   gem "net-smtp"
+  gem "concurrent-ruby", "1.3.4"
 
   group :development, :test do
     gem 'factory_girl_rails', :require => false
@@ -16,6 +17,7 @@ appraise "rails-6--twilio-7" do
   gem "sqlite3", "~> 1.4"
   gem "twilio-ruby", "~> 7.0"
   gem "net-smtp"
+  gem "concurrent-ruby", "1.3.4"
 
   group :development, :test do
     gem 'factory_girl_rails', :require => false
@@ -29,6 +31,7 @@ appraise "rails-6-1--twilio-6" do
   gem "sqlite3", "~> 1.4"
   gem "net-smtp"
   gem "twilio-ruby", "~> 6.9"
+  gem "concurrent-ruby", "1.3.4"
 
   group :development, :test do
     gem 'factory_girl_rails', :require => false
@@ -42,6 +45,7 @@ appraise "rails-6-1--twilio-7" do
   gem "sqlite3", "~> 1.4"
   gem "net-smtp"
   gem "twilio-ruby", "~> 7.0"
+  gem "concurrent-ruby", "1.3.4"
 
   group :development, :test do
     gem 'factory_girl_rails', :require => false
@@ -55,6 +59,7 @@ appraise "rails-7--twilio-6" do
   gem "sqlite3", "~> 1.4"
   gem "net-smtp"
   gem "twilio-ruby", "~> 6.9"
+  gem "concurrent-ruby", "1.3.4"
 
   group :development, :test do
     gem 'factory_girl_rails', :require => false
@@ -68,6 +73,7 @@ appraise "rails-7--twilio-7" do
   gem "sqlite3", "~> 1.4"
   gem "net-smtp"
   gem "twilio-ruby", "~> 7.0"
+  gem "concurrent-ruby", "1.3.4"
 
   group :development, :test do
     gem 'factory_girl_rails', :require => false

--- a/gemfiles/rails_6_1__twilio_6.gemfile
+++ b/gemfiles/rails_6_1__twilio_6.gemfile
@@ -6,6 +6,7 @@ gem "rails", "~> 6.1.0"
 gem "sqlite3", "~> 1.4"
 gem "net-smtp"
 gem "twilio-ruby", "~> 6.9"
+gem "concurrent-ruby", "1.3.4"
 
 group :development, :test do
   gem "factory_girl_rails", require: false

--- a/gemfiles/rails_6_1__twilio_7.gemfile
+++ b/gemfiles/rails_6_1__twilio_7.gemfile
@@ -6,6 +6,7 @@ gem "rails", "~> 6.1.0"
 gem "sqlite3", "~> 1.4"
 gem "net-smtp"
 gem "twilio-ruby", "~> 7.0"
+gem "concurrent-ruby", "1.3.4"
 
 group :development, :test do
   gem "factory_girl_rails", require: false

--- a/gemfiles/rails_6__twilio_6.gemfile
+++ b/gemfiles/rails_6__twilio_6.gemfile
@@ -6,6 +6,7 @@ gem "rails", "~> 6.0.0"
 gem "sqlite3", "~> 1.4"
 gem "twilio-ruby", "~> 6.9"
 gem "net-smtp"
+gem "concurrent-ruby", "1.3.4"
 
 group :development, :test do
   gem "factory_girl_rails", require: false

--- a/gemfiles/rails_6__twilio_7.gemfile
+++ b/gemfiles/rails_6__twilio_7.gemfile
@@ -6,6 +6,7 @@ gem "rails", "~> 6.0.0"
 gem "sqlite3", "~> 1.4"
 gem "twilio-ruby", "~> 7.0"
 gem "net-smtp"
+gem "concurrent-ruby", "1.3.4"
 
 group :development, :test do
   gem "factory_girl_rails", require: false

--- a/gemfiles/rails_7__twilio_6.gemfile
+++ b/gemfiles/rails_7__twilio_6.gemfile
@@ -6,6 +6,7 @@ gem "rails", "~> 7.0.0"
 gem "sqlite3", "~> 1.4"
 gem "net-smtp"
 gem "twilio-ruby", "~> 6.9"
+gem "concurrent-ruby", "1.3.4"
 
 group :development, :test do
   gem "factory_girl_rails", require: false

--- a/gemfiles/rails_7__twilio_7.gemfile
+++ b/gemfiles/rails_7__twilio_7.gemfile
@@ -6,6 +6,7 @@ gem "rails", "~> 7.0.0"
 gem "sqlite3", "~> 1.4"
 gem "net-smtp"
 gem "twilio-ruby", "~> 7.0"
+gem "concurrent-ruby", "1.3.4"
 
 group :development, :test do
   gem "factory_girl_rails", require: false


### PR DESCRIPTION
Works around this [bug](https://github.com/rails/rails/issues/54272)

Also corrects installing Gems by using the official ruby/setup-ruby Github Action.