### PR TITLE
Limit permissions for Github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This is recommended by CodeQL as a safety concern. It's unlikely to be a problem but it's good to limit anyways.