### PR TITLE
Add tests for Ruby 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", 3.1, 3.2, 3.3, 3.4]
+        ruby: ["3.0", 3.1, 3.2, 3.3, 3.4, "4.0"]
         rails: [rails_6, rails_6_1, rails_7, rails_7_1, rails_7_2, rails_8, rails_8_1]
         twilio: [twilio_6, twilio_7]
         exclude:
@@ -24,6 +24,12 @@ jobs:
             ruby: 3.4
           - rails: rails_7 # minitest from this version doesn't supporter Ruby 3.4
             ruby: 3.4
+          - rails: rails_6 # minitest from this version doesn't supporter Ruby 4.0
+            ruby: 4.0
+          - rails: rails_6_1 # minitest from this version doesn't supporter Ruby 4.0
+            ruby: 4.0
+          - rails: rails_7 # minitest from this version doesn't supporter Ruby 4.0
+            ruby: 4.0
           - rails: rails_8 # Rails 8 requires 3.2
             ruby: "3.0"
           - rails: rails_8 # Rails 8 requires 3.2


### PR DESCRIPTION
We previously weren't running our tests against Ruby 4.0. This sets up and runs tests against Ruby 4.0 as well.